### PR TITLE
[FEAT] PostgreSQL RDS 자원 생성

### DIFF
--- a/envs/prod/locals.tf
+++ b/envs/prod/locals.tf
@@ -1,12 +1,49 @@
 locals {
+
+  ### VPC ###
+
   vpc_name = "koo-blog"
   vpc_cidr = "10.1.0.0/16"
   public_subnet = {
     cidr_block        = "10.1.0.0/18"
     availability_zone = "ap-northeast-2a"
   }
-  private_subnet = {
-    cidr_block        = "10.1.64.0/18"
-    availability_zone = "ap-northeast-2a"
+  private_subnets = {
+    "private-subnet-1" = {
+      cidr_block        = "10.1.64.0/18"
+      availability_zone = "ap-northeast-2a"
+    }
+    "private-subnet-2" = {
+      cidr_block        = "10.1.128.0/18"
+      availability_zone = "ap-northeast-2b"
+    }
+  }
+
+  ### RDS ###
+
+  rds_instances = {
+    "koo-blog" = {
+      engine         = "postgres"
+      engine_version = "16.3"
+      instance_class = "db.t3.micro"
+
+      allocated_storage     = 20
+      max_allocated_storage = 20
+      storage_type          = "gp2"
+      storage_encrypted     = false
+
+      db_name  = "main"
+      username = var.koo_blog_username
+      password = var.koo_blog_password
+
+      publicly_accessible = false
+      multi_az            = false
+
+      backup_retention_period      = 0
+      monitoring_interval          = 0
+      performance_insights_enabled = false
+      deletion_protection          = false
+      skip_final_snapshot          = true
+    }
   }
 }

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -20,9 +20,41 @@ provider "aws" {
 }
 
 module "vpc" {
-  source         = "../../modules/vpc"
-  vpc_name       = local.vpc_name
-  vpc_cidr       = local.vpc_cidr
-  public_subnet  = local.public_subnet
-  private_subnet = local.private_subnet
+  source          = "../../modules/vpc"
+  vpc_name        = local.vpc_name
+  vpc_cidr        = local.vpc_cidr
+  public_subnet   = local.public_subnet
+  private_subnets = local.private_subnets
+}
+
+module "rds" {
+  for_each = local.rds_instances
+  source   = "../../modules/rds"
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnet_ids
+
+  identifier = each.key
+
+  engine         = each.value.engine
+  engine_version = each.value.engine_version
+  instance_class = each.value.instance_class
+
+  allocated_storage     = each.value.allocated_storage
+  max_allocated_storage = each.value.max_allocated_storage
+  storage_type          = each.value.storage_type
+  storage_encrypted     = each.value.storage_encrypted
+
+  db_name  = each.value.db_name
+  username = each.value.username
+  password = each.value.password
+
+  publicly_accessible = each.value.publicly_accessible
+  multi_az            = each.value.multi_az
+
+  backup_retention_period      = each.value.backup_retention_period
+  monitoring_interval          = each.value.monitoring_interval
+  performance_insights_enabled = each.value.performance_insights_enabled
+  deletion_protection          = each.value.deletion_protection
+  skip_final_snapshot          = each.value.skip_final_snapshot
 }

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -1,0 +1,9 @@
+variable "koo_blog_username" {
+  type        = string
+  description = "Koo Blog 관리자 사용자 이름"
+}
+
+variable "koo_blog_password" {
+  type        = string
+  description = "Koo Blog 관리자 사용자 비밀번호"
+}

--- a/modules/rds/maint.tf
+++ b/modules/rds/maint.tf
@@ -1,0 +1,52 @@
+resource "aws_db_instance" "main" {
+  identifier = var.identifier
+
+  engine         = var.engine
+  engine_version = var.engine_version
+  instance_class = var.instance_class
+
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = var.max_allocated_storage
+  storage_type          = var.storage_type
+  storage_encrypted     = var.storage_encrypted
+
+  db_name  = var.db_name
+  username = var.username
+  password = var.password
+
+  db_subnet_group_name   = aws_db_subnet_group.main.id
+  vpc_security_group_ids = [aws_security_group.main.id]
+  publicly_accessible    = var.publicly_accessible
+  multi_az               = var.multi_az
+
+  backup_retention_period      = var.backup_retention_period
+  monitoring_interval          = var.monitoring_interval
+  performance_insights_enabled = var.performance_insights_enabled
+  deletion_protection          = var.deletion_protection
+  skip_final_snapshot          = var.skip_final_snapshot
+
+  tags = {
+    Name      = var.identifier
+    ManagedBy = "Terraform"
+  }
+}
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.identifier}-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name      = "${var.identifier}-subnet-group"
+    ManagedBy = "Terraform"
+  }
+}
+
+resource "aws_security_group" "main" {
+  name   = "${var.identifier}-security-group"
+  vpc_id = var.vpc_id
+
+  tags = {
+    Name      = "${var.identifier}-security-group"
+    ManagedBy = "Terraform"
+  }
+}

--- a/modules/rds/varialbes.tf
+++ b/modules/rds/varialbes.tf
@@ -1,0 +1,99 @@
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "DB 서브넷 그룹 ID"
+}
+
+variable "identifier" {
+  type        = string
+  description = "RDS 인스턴스 이름"
+}
+
+variable "engine" {
+  type        = string
+  description = "RDS 엔진"
+}
+
+variable "engine_version" {
+  type        = string
+  description = "RDS 엔진 버전"
+}
+
+variable "instance_class" {
+  type        = string
+  description = "RDS 인스턴스 클래스"
+}
+
+variable "allocated_storage" {
+  type        = number
+  description = "DB 인스턴스 저장소 용량"
+}
+
+variable "max_allocated_storage" {
+  type        = number
+  description = "DB 인스턴스 최대 저장소 용량"
+}
+
+variable "storage_type" {
+  type        = string
+  description = "DB 인스턴스 저장소 타입"
+}
+
+variable "storage_encrypted" {
+  type        = bool
+  description = "DB 인스턴스 저장소 암호화 여부"
+}
+
+variable "db_name" {
+  type        = string
+  description = "DB 이름"
+}
+
+variable "username" {
+  type        = string
+  description = "DB 사용자 이름"
+}
+
+variable "password" {
+  type        = string
+  description = "DB 사용자 비밀번호"
+}
+
+variable "publicly_accessible" {
+  type        = bool
+  description = "DB 인스턴스 공개 여부"
+}
+
+variable "multi_az" {
+  type        = bool
+  description = "DB 인스턴스 다중 가용 영역 여부"
+}
+
+variable "backup_retention_period" {
+  type        = number
+  description = "DB 백업 보존 기간"
+}
+
+variable "monitoring_interval" {
+  type        = number
+  description = "DB 모니터링 간격"
+}
+
+variable "performance_insights_enabled" {
+  type        = bool
+  description = "DB 성능 인사이트 활성화 여부"
+}
+
+variable "deletion_protection" {
+  type        = bool
+  description = "DB 인스턴스 삭제 보호 여부"
+}
+
+variable "skip_final_snapshot" {
+  type        = bool
+  description = "DB 인스턴스 삭제 시 스냅샷 생성 여부"
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -28,12 +28,13 @@ resource "aws_subnet" "public" {
 }
 
 resource "aws_subnet" "private" {
+  for_each          = var.private_subnets
   vpc_id            = aws_vpc.main.id
-  cidr_block        = var.private_subnet.cidr_block
-  availability_zone = var.private_subnet.availability_zone
+  cidr_block        = each.value.cidr_block
+  availability_zone = each.value.availability_zone
 
   tags = {
-    Name      = "${var.vpc_name}-private-subnet"
+    Name      = "${var.vpc_name}-${each.key}"
     ManagedBy = "Terraform"
   }
 }

--- a/modules/vpc/output.tf
+++ b/modules/vpc/output.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_id" {
+  value = aws_subnet.public.id
+}
+
+output "private_subnet_ids" {
+  value = [for subnet in aws_subnet.private : subnet.id]
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -13,7 +13,7 @@ variable "public_subnet" {
   description = "퍼블릭 서브넷 설정 정보"
 }
 
-variable "private_subnet" {
-  type        = map(string)
+variable "private_subnets" {
+  type        = map(map(string))
   description = "프라이빗 서브넷 설정 정보"
 }


### PR DESCRIPTION
# 1️⃣ 수정사항
- Private 서브넷 1개 추가 생성 (기존 1개)
   RDS 서브넷 그룹은 최소 두개의 서브넷이 지정되어야 하기 때문
 
- RDS 서브넷 그룹 생성
  Private 서브넷 2개가 포함됨
 
- RDS 보안그룹 생성
  서버 자원을 만들지 않았으므로 ingress, engress 규칙 생성 X

- RDS 생성
  `t3.micro` 인스턴스의 PostgreSQL RDS 생성

